### PR TITLE
Allow running as either `cargo benchcmp` or `cargo-benchcmp`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ extern crate prettytable;
 #[macro_use]
 extern crate quickcheck;
 
+use std::env;
 use std::io::{self, BufRead};
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -80,8 +81,28 @@ enum When {
     Auto,
 }
 
+fn get_argv() -> Vec<String> {
+    // Unify `cargo benchcmp` and `cargo-benchcmp` invocations' argv by adding
+    // "benchcmp" to the latter.
+
+    let first_arg_is_cargo_benchcmp = env::args().next()
+        .map(|a| a.ends_with("cargo-benchcmp"))
+        .unwrap_or(false);
+
+    let argv: Vec<_> = if first_arg_is_cargo_benchcmp {
+        let mut argv: Vec<_> = env::args().collect();
+        argv.insert(1, "benchcmp".into());
+        argv
+    } else {
+        env::args().collect()
+    };
+
+    argv
+}
+
 fn main() {
     let args: Args = Docopt::new(USAGE)
+        .map(|d| d.argv(get_argv()))
         .and_then(|d| d.version(Some(version())).decode())
         .unwrap_or_else(|e| e.exit());
     if let Err(e) = args.run() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13,7 +13,6 @@ macro_rules! new_scene {
 
 fn new_ucmd() -> second_law::UCommand {
     let mut scene: second_law::Scene = new_scene!();
-    scene.subcmd_arg("benchcmp");
     scene.ucmd()
 }
 
@@ -55,7 +54,6 @@ fn non_overlapping_input() {
 #[test]
 fn different_input_colored() {
     let mut scene: second_law::Scene = new_scene!();
-    scene.subcmd_arg("benchcmp");
     // NOTE: keeping the environment here so that terminfo is available,
     //  which is required to get colour code in the output
     scene.ucmd_keepenv()


### PR DESCRIPTION
Fixes #20.

Had to change the docopt usage string. Unsure if there is a better way.
