### PR TITLE
Display a message when there are no rows in the output table

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,10 +136,14 @@ impl Args {
                 output.add_row(c.to_row(self.flag_variance, regression));
             }
 
-            match self.flag_color {
-                When::Auto => output.printstd(),
-                When::Never => try!(output.print(&mut io::stdout())),
-                When::Always => output.print_tty(true),
+            if output.len() > 1 {
+                match self.flag_color {
+                    When::Auto => output.printstd(),
+                    When::Never => try!(output.print(&mut io::stdout())),
+                    When::Always => output.print_tty(true),
+                }
+            } else {
+                eprintln!("WARNING: nothing to output");
             }
         }
 

--- a/tests/fixtures/bench_output_4.txt
+++ b/tests/fixtures/bench_output_4.txt
@@ -1,0 +1,5 @@
+running 84 tests
+test dense::ac_one_byte                               ... bench:         349 ns/iter (+/- 5) = 28653 MB/s
+test dense::ac_one_prefix_byte_every_match            ... bench:     112,957 ns/iter (+/- 1,480) = 88 MB/s
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured

--- a/tests/fixtures/bench_output_5.txt
+++ b/tests/fixtures/bench_output_5.txt
@@ -1,0 +1,5 @@
+running 84 tests
+test dense::ac_one_byte                               ... bench:         349 ns/iter (+/- 4) = 28653 MB/s
+test dense::ac_one_prefix_byte_every_match            ... bench:     112,957 ns/iter (+/- 1,490) = 88 MB/s
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured

--- a/tests/fixtures/empty_results.expected
+++ b/tests/fixtures/empty_results.expected
@@ -1,0 +1,1 @@
+WARNING: nothing to output

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -81,3 +81,12 @@ fn stdin() {
         .no_stderr()
         .stdout_is_fixture("different_input_selections.expected");
 }
+
+#[test]
+fn empty_results() {
+    new_ucmd()
+        .args(&["bench_output_4.txt", "bench_output_5.txt", "--threshold", "1"])
+        .succeeds()
+        .no_stdout()
+        .stderr_is_fixture("empty_results.expected");
+}


### PR DESCRIPTION
Rather than printing an empty table and making the user think they might have
messed up, warn that there is nothing to output.

Fixes #23
