### PR TITLE
List missing benchmarks

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -154,7 +154,7 @@ impl Benchmark {
         }
     }
 
-    fn fmt_ns(&self, variance: bool) -> String {
+    pub fn fmt_ns(&self, variance: bool) -> String {
         let mut res = commafy(self.ns);
         if variance {
             res = format!("{} (+/- {})", res, self.variance);


### PR DESCRIPTION
Fixes #27 

I added this behind a command line flag, but if you think it would be appropriate, I could make it enabled by default and make the flag disable it. I left the warning in, but only printed it if the user did not enable missing benchmarks.

Below is how it looks. I fed in some of my own benchmark results. I couldn't get the integration tests to pass on my machine, so I'm going to wait for the Travis output and see what adjustments I need to make.

Let me know if you have any feedback!

```
$ cat old
running 8 tests
test b01_compile_trivial   ... bench:       2,132 ns/iter (+/- 673)
test b02_compile_large     ... bench:   1,594,916 ns/iter (+/- 78,139)
test b03_compile_huge      ... bench:  51,480,362 ns/iter (+/- 1,144,024)
test b04_compile_simple    ... bench:      31,399 ns/iter (+/- 868)
test b05_compile_slow      ... bench:     225,000 ns/iter (+/- 5,625)
test b06_interpret_trivial ... bench:      10,325 ns/iter (+/- 221)
test b07_interpret_simple  ... bench:   6,740,466 ns/iter (+/- 81,711)
test b08_interpret_slow    ... ignored

test result: ok. 0 passed; 0 failed; 1 ignored; 7 measured

     Running target/release/deps/brainfuck-ca6ac36e58b54315

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured

     Running target/release/deps/brainfuck-184a47abc46cc402

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
```

```
$ cat new
running 16 tests
test b01_compile_trivial       ... bench:       2,829 ns/iter (+/- 279)
test b01_compile_trivial_opt   ... bench:       1,746 ns/iter (+/- 55)
test b02_compile_large         ... bench:   2,516,662 ns/iter (+/- 392,982)
test b02_compile_large_opt     ... bench:   1,039,463 ns/iter (+/- 71,707)
test b03_compile_huge          ... bench:  86,575,722 ns/iter (+/- 3,605,019)
test b03_compile_huge_opt      ... bench:  15,571,740 ns/iter (+/- 1,062,383)
test b04_compile_simple        ... bench:      44,247 ns/iter (+/- 490)
test b04_compile_simple_opt    ... bench:      24,441 ns/iter (+/- 255)
test b05_compile_slow          ... bench:     289,571 ns/iter (+/- 3,150)
test b05_compile_slow_opt      ... bench:     158,586 ns/iter (+/- 2,301)
test b06_interpret_trivial     ... bench:      10,442 ns/iter (+/- 46)
test b06_interpret_trivial_opt ... bench:       5,634 ns/iter (+/- 19)
test b07_interpret_simple      ... bench:   7,388,517 ns/iter (+/- 34,084)
test b07_interpret_simple_opt  ... bench:   4,114,281 ns/iter (+/- 18,730)
test b08_interpret_slow        ... ignored
test b08_interpret_slow_opt    ... ignored

test result: ok. 0 passed; 0 failed; 2 ignored; 14 measured

     Running target/release/deps/brainfuck-ca6ac36e58b54315

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured

     Running target/release/deps/brainfuck-184a47abc46cc402

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
```

```
$ cargo run -- benchcmp old new --include-missing
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/cargo-benchcmp benchcmp old new --include-missing`
 name                       old ns/iter  new ns/iter  diff ns/iter  diff % 
 b01_compile_trivial        2,132        2,829                 697  32.69% 
 b02_compile_large          1,594,916    2,516,662         921,746  57.79% 
 b03_compile_huge           51,480,362   86,575,722     35,095,360  68.17% 
 b04_compile_simple         31,399       44,247             12,848  40.92% 
 b05_compile_slow           225,000      289,571            64,571  28.70% 
 b06_interpret_trivial      10,325       10,442                117   1.13% 
 b07_interpret_simple       6,740,466    7,388,517         648,051   9.61% 
 b01_compile_trivial_opt    n/a          1,746                 n/a     n/a 
 b02_compile_large_opt      n/a          1,039,463             n/a     n/a 
 b03_compile_huge_opt       n/a          15,571,740            n/a     n/a 
 b04_compile_simple_opt     n/a          24,441                n/a     n/a 
 b05_compile_slow_opt       n/a          158,586               n/a     n/a 
 b06_interpret_trivial_opt  n/a          5,634                 n/a     n/a 
 b07_interpret_simple_opt   n/a          4,114,281             n/a     n/a
```
![screenshot from 2017-04-19 12-39-52](https://cloud.githubusercontent.com/assets/530939/25191367/5575f994-24fd-11e7-8e53-fcdcc0ebef9f.png)

```
$ cargo run -- benchcmp new old --include-missing
   Compiling cargo-benchcmp v0.1.5 (file:///home/sunjay/Documents/projects/cargo-benchcmp)
    Finished dev [unoptimized + debuginfo] target(s) in 3.9 secs
     Running `target/debug/cargo-benchcmp benchcmp new old --include-missing`
 name                       new ns/iter  old ns/iter  diff ns/iter   diff % 
 b01_compile_trivial        2,829        2,132                -697  -24.64% 
 b02_compile_large          2,516,662    1,594,916        -921,746  -36.63% 
 b03_compile_huge           86,575,722   51,480,362    -35,095,360  -40.54% 
 b04_compile_simple         44,247       31,399            -12,848  -29.04% 
 b05_compile_slow           289,571      225,000           -64,571  -22.30% 
 b06_interpret_trivial      10,442       10,325               -117   -1.12% 
 b07_interpret_simple       7,388,517    6,740,466        -648,051   -8.77% 
 b01_compile_trivial_opt    1,746        n/a                   n/a      n/a 
 b02_compile_large_opt      1,039,463    n/a                   n/a      n/a 
 b03_compile_huge_opt       15,571,740   n/a                   n/a      n/a 
 b04_compile_simple_opt     24,441       n/a                   n/a      n/a 
 b05_compile_slow_opt       158,586      n/a                   n/a      n/a 
 b06_interpret_trivial_opt  5,634        n/a                   n/a      n/a 
 b07_interpret_simple_opt   4,114,281    n/a                   n/a      n/a 
```
![screenshot from 2017-04-19 12-40-02](https://cloud.githubusercontent.com/assets/530939/25191368/55764890-24fd-11e7-893f-04956d411d58.png)

