### PR TITLE
Sync Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cargo-benchcmp"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "docopt 0.6.86 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
The file got out of sync when version 0.2.0 was released.