### PR TITLE
Improve empty result messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,13 @@ name = "cargo-benchcmp"
 version = "0.2.0"
 dependencies = [
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "prettytable-rs 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "second_law 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -30,29 +30,48 @@ dependencies = [
 
 [[package]]
 name = "atty"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "docopt"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "encode_unicode"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -60,7 +79,7 @@ name = "env_logger"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -75,25 +94,42 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.22"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "magenta"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "magenta-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -101,29 +137,29 @@ name = "memchr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "prettytable-rs"
-version = "0.6.6"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "encode_unicode 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encode_unicode 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "quickcheck"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -133,10 +169,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -183,12 +233,12 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -233,16 +283,26 @@ name = "tempdir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "term"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -251,7 +311,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -267,7 +327,7 @@ name = "thread_local"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -317,33 +377,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
-"checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
+"checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
+"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+"checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b5b93718f8b3e5544fcc914c43de828ca6c6ace23e0332c6080a2977b49787a"
-"checksum encode_unicode 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebaa362d9b3b3a22633c78c58c87da02ec16c0541abfe3eecdd022eb4a08ede8"
+"checksum encode_unicode 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c088ec0ed2282dcd054f2c124c0327f953563e6c75fdc6ff5141779596289830"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum libc 0.2.22 (registry+https://github.com/rust-lang/crates.io-index)" = "babb8281da88cba992fa1f4ddec7d63ed96280a1a53ec9b919fd37b53d71e502"
-"checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
+"checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
+"checksum libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d1419b2939a0bc44b77feb34661583c7546b532b192feab36249ab584b86856c"
+"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
+"checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
+"checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
-"checksum prettytable-rs 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "688511bfaadcbbd46b7cc18cc189e5726da4d17f95027e07b18cf417fdbfc5e4"
-"checksum quickcheck 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0b333da40686cc05db13d933f8e7b450f403cfc5a4d005154d8d4a5ba9d14605"
+"checksum prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "34dc1f4f6dddab3bf008ecfd4fd2a631b585fbf0af123f34c1324f51a034ff5f"
+"checksum quickcheck 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "02c2411d418cea2364325b18a205664f9ef8252e06b2e911db97c0b0d98b1406"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
+"checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
+"checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum second_law 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cf0fe2a56a61f10717099dfb9a1c1dedb6f557affe27b3e228a1ffa3419c7ec1"
-"checksum serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "bcb6a7637a47663ee073391a139ed07851f27ed2532c2abc88c6bf27a16cdf34"
-"checksum serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "812ff66056fd9a9a5b7c119714243b0862cf98340e7d4b5ee05a932c40d5ea6c"
+"checksum serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7046c9d4c6c522d10b2d098f9bebe2bef227e0e74044d8c1bfcf6b476af799"
+"checksum serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1afcaae083fd1c46952a315062326bc9957f182358eb7da03b57ef1c688f7aa9"
 "checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
-"checksum term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d168af3930b369cfe245132550579d47dfd873d69470755a19c2c6568dbbd989"
+"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ version = "0.6.6"
 default-features = false # Don't use crlf on windows
 
 [dev-dependencies]
-quickcheck = "0.3.1"
+quickcheck = "0.4"
 second_law = "0.2.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,42 @@ impl Args {
                     When::Always => output.print_tty(true),
                 }
             } else {
-                eprintln!("WARNING: nothing to output");
+                let comparisions = benches.comparisons().len();
+                let improvements = benches.comparisons().iter().filter(|c| c.diff_ns <= 0).count();
+                let regressions = comparisions - improvements;
+
+                match (self.flag_threshold, self.flag_improvements, self.flag_regressions) {
+                    (Some(threshold), false, false) => {
+                        eprintln!(
+                            "All ({}) benchmarks are within a {}% threshold",
+                            comparisions,
+                            threshold,
+                        )
+                    }
+                    (Some(threshold), true, false) if improvements > 0 => {
+                        eprintln!(
+                            "All ({}/{}) improvements are within a {}% threshold",
+                            improvements,
+                            comparisions,
+                            threshold,
+                        )
+                    }
+                    (_, true, false) => {
+                        eprintln!("{}/{} benchmarks improved", improvements, comparisions)
+                    }
+                    (Some(threshold), false, true) if regressions > 0 => {
+                        eprintln!(
+                            "All ({}/{}) regressions are within a {}% threshold",
+                            regressions,
+                            comparisions,
+                            threshold,
+                        )
+                    }
+                    (_, false, true) => {
+                        eprintln!("{}/{} benchmarks regressed", regressions, comparisions)
+                    }
+                    _ => eprintln!("WARNING: nothing to output"),
+                }
             }
         }
 

--- a/tests/fixtures/4_cmp_5_within_threshold.expected
+++ b/tests/fixtures/4_cmp_5_within_threshold.expected
@@ -1,0 +1,1 @@
+All (2) benchmarks are within a 1% threshold

--- a/tests/fixtures/6_cmp_7_within_threshold.expected
+++ b/tests/fixtures/6_cmp_7_within_threshold.expected
@@ -1,0 +1,1 @@
+All (5) benchmarks are within a 12% threshold

--- a/tests/fixtures/6_cmp_7_within_threshold_improvements.expected
+++ b/tests/fixtures/6_cmp_7_within_threshold_improvements.expected
@@ -1,0 +1,1 @@
+All (3/5) improvements are within a 3% threshold

--- a/tests/fixtures/6_cmp_7_within_threshold_regressions.expected
+++ b/tests/fixtures/6_cmp_7_within_threshold_regressions.expected
@@ -1,0 +1,1 @@
+All (2/5) regressions are within a 4% threshold

--- a/tests/fixtures/bench_output_6.txt
+++ b/tests/fixtures/bench_output_6.txt
@@ -1,0 +1,9 @@
+
+running 84 tests
+test dense::ac_one_byte                               ... bench:         349 ns/iter (+/- 5) = 28653 MB/s
+test dense::ac_one_prefix_byte_every_match            ... bench:     112,957 ns/iter (+/- 1,480) = 88 MB/s
+test dense::ac_one_prefix_byte_no_match               ... bench:         350 ns/iter (+/- 15) = 28571 MB/s
+test dense::ac_one_prefix_byte_random                 ... bench:      16,096 ns/iter (+/- 292) = 621 MB/s
+test dense::ac_ten_bytes                              ... bench:      58,588 ns/iter (+/- 218) = 170 MB/s
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured

--- a/tests/fixtures/bench_output_7.txt
+++ b/tests/fixtures/bench_output_7.txt
@@ -1,0 +1,9 @@
+
+running 84 tests
+test dense::ac_one_byte                               ... bench:         351 ns/iter (+/- 6) = 28653 MB/s
+test dense::ac_one_prefix_byte_every_match            ... bench:     112,960 ns/iter (+/- 1,482) = 88 MB/s
+test dense::ac_one_prefix_byte_no_match               ... bench:         350 ns/iter (+/- 14) = 28571 MB/s
+test dense::ac_one_prefix_byte_random                 ... bench:      16,090 ns/iter (+/- 291) = 621 MB/s
+test dense::ac_ten_bytes                              ... bench:      58,580 ns/iter (+/- 215) = 170 MB/s
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured

--- a/tests/fixtures/bench_output_8.txt
+++ b/tests/fixtures/bench_output_8.txt
@@ -1,0 +1,5 @@
+running 84 tests
+test dense::ac_one_byte                               ... bench:         350 ns/iter (+/- 4) = 28653 MB/s
+test dense::ac_one_prefix_byte_every_match            ... bench:     112,960 ns/iter (+/- 1,490) = 88 MB/s
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 2 measured

--- a/tests/fixtures/zero_improvements.expected
+++ b/tests/fixtures/zero_improvements.expected
@@ -1,0 +1,1 @@
+0/2 benchmarks improved

--- a/tests/fixtures/zero_regressions.expected
+++ b/tests/fixtures/zero_regressions.expected
@@ -1,0 +1,1 @@
+0/2 benchmarks regressed

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -87,8 +87,80 @@ fn stdin() {
 #[test]
 fn empty_results() {
     new_ucmd()
-        .args(&["bench_output_4.txt", "bench_output_5.txt", "--threshold", "1"])
+        .args(&["bench_output_4.txt", "bench_output_5.txt", "--regressions", "--improvements"])
         .succeeds()
         .no_stdout()
         .stderr_is_fixture("empty_results.expected");
+}
+
+#[test]
+fn within_threshold_1_comparing_4_5() {
+    new_ucmd()
+        .args(&["bench_output_4.txt", "bench_output_5.txt", "--threshold", "1"])
+        .succeeds()
+        .no_stdout()
+        .stderr_is_fixture("4_cmp_5_within_threshold.expected");
+}
+
+#[test]
+fn within_threshold_12_comparing_6_7() {
+    new_ucmd()
+        .args(&["bench_output_6.txt", "bench_output_7.txt", "--threshold", "12"])
+        .succeeds()
+        .no_stdout()
+        .stderr_is_fixture("6_cmp_7_within_threshold.expected");
+}
+
+#[test]
+fn within_threshold_3_comparing_6_7_improvements() {
+    new_ucmd()
+        .args(&["bench_output_6.txt", "bench_output_7.txt", "--threshold", "3", "--improvements"])
+        .succeeds()
+        .no_stdout()
+        .stderr_is_fixture("6_cmp_7_within_threshold_improvements.expected");
+}
+
+#[test]
+fn within_threshold_4_comparing_6_7_regressions() {
+    new_ucmd()
+        .args(&["bench_output_6.txt", "bench_output_7.txt", "--threshold", "4", "--regressions"])
+        .succeeds()
+        .no_stdout()
+        .stderr_is_fixture("6_cmp_7_within_threshold_regressions.expected");
+}
+
+#[test]
+fn zero_regressions() {
+    new_ucmd()
+        .args(&["bench_output_4.txt", "bench_output_5.txt", "--regressions"])
+        .succeeds()
+        .no_stdout()
+        .stderr_is_fixture("zero_regressions.expected");
+}
+
+#[test]
+fn zero_regressions_threshold() {
+    new_ucmd()
+        .args(&["bench_output_4.txt", "bench_output_5.txt", "--threshold", "2", "--regressions"])
+        .succeeds()
+        .no_stdout()
+        .stderr_is_fixture("zero_regressions.expected");
+}
+
+#[test]
+fn zero_improvements() {
+    new_ucmd()
+        .args(&["bench_output_4.txt", "bench_output_8.txt", "--improvements"])
+        .succeeds()
+        .no_stdout()
+        .stderr_is_fixture("zero_improvements.expected");
+}
+
+#[test]
+fn zero_improvements_threshold() {
+    new_ucmd()
+        .args(&["bench_output_4.txt", "bench_output_8.txt", "--threshold", "2", "--improvements"])
+        .succeeds()
+        .no_stdout()
+        .stderr_is_fixture("zero_improvements.expected");
 }


### PR DESCRIPTION
This PR replaces the ***WARNING: nothing to output*** message in the cases we can output something more useful.

For example (using the test bench outputs)
`cargo benchcmp bench_output_4.txt bench_output_5.txt --threshold 2 --improvements`
yields
***All (2/2) improvements are within a 2% threshold***

Changes
* Add `0/$n benchmarks improved` message
* Add `0/$n benchmarks regressed` message
* Add `All ($n) benchmarks are within a $t% threshold` message
* Add `All ($r/$n) regressions are within a $t% threshold` message
* Add `All ($i/$n) improvements are within a $t% threshold` message
* Update dependencies

