### PR TITLE
Automatically merge measurements from concatenated runs of benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,13 @@ $ cargo benchcmp old new --regressions --threshold 2
  name                                full:: ns/iter     full_overlap:: ns/iter  diff ns/iter  diff %  speedup
  ac_ten_one_prefix_byte_every_match  27,424 (364 MB/s)  28,046 (356 MB/s)                622   2.27%   x 0.98
 ```
+
+You can also concatenate measurements of the same version of benchmarks, to reduce noise.
+```
+$ cargo bench >> control
+```
+When comparing a file with multiple measurements of the same benchmark name in it,
+benchcmp will consider only the quickest measurement,
+and assume the other measurements were more affected by transient noise.
+If multiple measurements of the same name in in the same file are equally quick,
+benchcmp picks the one with the lowest variance.

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -140,6 +140,16 @@ impl FromStr for Benchmark {
 }
 
 impl Benchmark {
+    /// Compares two results of a benchmark pulled from the same report
+    /// and decides whether self is a better result to compare with.
+    pub fn is_better_than(&self, other: &Benchmark) -> bool {
+        match self.ns.cmp(&other.ns) {
+            cmp::Ordering::Less => true,
+            cmp::Ordering::Equal => self.variance < other.variance,
+            cmp::Ordering::Greater => false,
+        }
+    }
+
     /// Compares an old benchmark (self) with a new benchmark.
     pub fn compare(self, new: Benchmark) -> Comparison {
         let diff_ns = new.ns as i64 - self.ns as i64;

--- a/tests/fixtures/bench_output_8_repeated.txt
+++ b/tests/fixtures/bench_output_8_repeated.txt
@@ -1,0 +1,5 @@
+test dense::ac_one_byte                               ... bench:         500 ns/iter (+/- 3) = 20000 MB/s
+test dense::ac_one_byte                               ... bench:         350 ns/iter (+/- 4) = 28653 MB/s
+test dense::ac_one_byte                               ... bench:         350 ns/iter (+/- 3) = 28653 MB/s
+test dense::ac_one_byte                               ... bench:         450 ns/iter (+/- 2) = 22222 MB/s
+test dense::ac_one_prefix_byte_every_match            ... bench:     112,960 ns/iter (+/- 1,490) = 88 MB/s

--- a/tests/fixtures/repeated_runs.expected
+++ b/tests/fixtures/repeated_runs.expected
@@ -1,0 +1,3 @@
+ name                                   bench_output_8.txt ns/iter    bench_output_8_repeated.txt ns/iter  diff ns/iter  diff %  speedup 
+ dense::ac_one_byte                     350 (+/- 4) (28653 MB/s)      350 (+/- 3) (28653 MB/s)                        0   0.00%   x 1.00 
+ dense::ac_one_prefix_byte_every_match  112,960 (+/- 1490) (88 MB/s)  112,960 (+/- 1490) (88 MB/s)                    0   0.00%   x 1.00 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -293,3 +293,12 @@ fn zero_improvements_threshold() {
         .no_stdout()
         .stderr_is(include_str!("fixtures/zero_improvements.expected"));
 }
+
+#[test]
+fn repeated_runs() {
+    new_cmd()
+        .args(&["bench_output_8.txt", "bench_output_8_repeated.txt", "--variance"])
+        .succeeds()
+        .no_stderr()
+        .stdout_is(include_str!("fixtures/repeated_runs.expected"));
+}


### PR DESCRIPTION
Allow reading concatenated benchmark output files and picking the best result. I find this gives a much more stable comparison.