### PR TITLE
Allow parsing fractional `libtest` output

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -106,9 +106,9 @@ impl PartialOrd for Benchmark {
 lazy_static! {
     static ref BENCHMARK_REGEX: Regex = Regex::new(r##"(?x)
         test\s+(?P<name>\S+)                        # test   mod::test_name
-        \s+...\sbench:\s+(?P<ns>[0-9,]+)\s+ns/iter  # ... bench: 1234 ns/iter
-        \s+\(\+/-\s+(?P<variance>[0-9,]+)\)         # (+/- 4321)
-        (?:\s+=\s+(?P<throughput>[0-9,]+)\sMB/s)?   # =   2314 MB/s
+        \s+...\sbench:\s+(?P<ns>[0-9,.]+)\s+ns/iter  # ... bench: 1234 ns/iter
+        \s+\(\+/-\s+(?P<variance>[0-9,.]+)\)         # (+/- 4321)
+        (?:\s+=\s+(?P<throughput>[0-9,.]+)\sMB/s)?   # =   2314 MB/s
     "##).unwrap();
 }
 
@@ -273,7 +273,7 @@ fn parse_commas(s: &str) -> Option<u64> {
 
 /// Drops all commas in a string
 fn drop_commas(s: &str) -> String {
-    s.chars().filter(|&b| b != ',').collect()
+    s.chars().take_while(|&c| c != '.').filter(|&c| c != ',').collect()
 }
 
 /// Commafy a number as a string.

--- a/tests/fixtures/bench_output_fraction.txt
+++ b/tests/fixtures/bench_output_fraction.txt
@@ -1,0 +1,6 @@
+running 4 tests
+test add  ... bench:           1.24 ns/iter (+/- 0.00)
+test add2 ... bench:           1.48 ns/iter (+/- 0.01)
+test add3 ... bench:           1.72 ns/iter (+/- 0.01)
+test add4 ... bench:           1.96 ns/iter (+/- 0.01)
+test empty ... bench:           1.24 ns/iter (+/- 0.00)

--- a/tests/fixtures/same_input_fractional.expected
+++ b/tests/fixtures/same_input_fractional.expected
@@ -1,0 +1,6 @@
+ name   bench_output_fraction.txt ns/iter  bench_output_fraction.txt ns/iter  diff ns/iter  diff %  speedup 
+ add    1                                  1                                             0   0.00%   x 1.00 
+ add2   1                                  1                                             0   0.00%   x 1.00 
+ add3   1                                  1                                             0   0.00%   x 1.00 
+ add4   1                                  1                                             0   0.00%   x 1.00 
+ empty  1                                  1                                             0   0.00%   x 1.00 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -164,6 +164,14 @@ fn same_input() {
 }
 
 #[test]
+fn same_input_fractional() {
+    new_cmd()
+        .args(&["bench_output_fraction.txt", "bench_output_fraction.txt"])
+        .succeeds()
+        .stdout_is(include_str!("fixtures/same_input_fractional.expected"));
+}
+
+#[test]
 fn different_input() {
     new_cmd()
         .args(&["bench_output_2.txt", "bench_output_3.txt"])


### PR DESCRIPTION
This will now parse, but silently truncate the new fractional `libtest` output.

Fixes #48